### PR TITLE
Смена цветов ламп при различных кодах безопасности

### DIFF
--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -86,6 +86,16 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	for(var/area/A in world)
 		if(istype(A, /area/hallway))
 			A.readyalert()
+			if(get_security_level() == "delta")
+				for(var/obj/machinery/light/LT in A.contents)
+					LT.alert_collor()
+	if(get_security_level() != "delta")
+		for(var/obj/machinery/light/LAMPS in machines)
+			if(pick(1,0) == 1)
+				if(get_security_level() == "red")	LAMPS.color_state = 0
+				else
+					LAMPS.set_light(l_range = LAMPS.light_range, l_power = LAMPS.light_power, l_color = "#FF6F6F")
+					LAMPS.color_state = 0
 
 //calls the shuttle for a routine crew transfer
 /datum/emergency_shuttle_controller/proc/call_transfer()
@@ -115,6 +125,10 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 			if(istype(A, /area/hallway))
 				A.readyreset()
 		evac = 0
+		for(var/obj/machinery/light/LT in machines)
+			LT.set_light(l_range = LT.light_range, l_power = LT.light_power, l_color = LT.standart_color)
+			if(pick(1,0) == 1)
+				LT.alert_collor(0,1)
 	else
 		priority_announcement.Announce("Шаттл отозван.")
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1083,6 +1083,8 @@ FIRE ALARM
 	var/area/area = get_area(src)
 	for(var/obj/machinery/firealarm/FA in area)
 		fire_alarm.clearAlarm(loc, FA)
+	for(var/obj/machinery/light/LT in area)
+		LT.alert_collor(0, 1)
 	update_icon()
 	return
 
@@ -1092,6 +1094,8 @@ FIRE ALARM
 	var/area/area = get_area(src)
 	for(var/obj/machinery/firealarm/FA in area)
 		fire_alarm.triggerAlarm(loc, FA, duration)
+	for(var/obj/machinery/light/LT in area)
+		LT.alert_collor(1)
 	update_icon()
 	//playsound(src.loc, 'sound/ambience/signal.ogg', 75, 0)
 	return

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -145,6 +145,8 @@
 	var/brightness_range = 8	// luminosity when on, also used in power calculation
 	var/brightness_power = 3
 	var/brightness_color = null
+	var/standart_color = "#FFFFFF"
+	var/color_state = 1
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = 0
 	var/light_type = /obj/item/weapon/light/tube		// the type of light item
@@ -163,18 +165,22 @@
 	brightness_range = 6
 	brightness_power = 2
 	brightness_color = "#a0a080"
+	standart_color = "#a0a080"
 	desc = "A small lighting fixture."
 	light_type = /obj/item/weapon/light/bulb
+
 
 /obj/machinery/light/small/emergency
 	brightness_range = 6
 	brightness_power = 2
 	brightness_color = "#da0205"
+	standart_color = "#da0205"
 
 /obj/machinery/light/small/red
 	brightness_range = 5
 	brightness_power = 1
 	brightness_color = "#da0205"
+	standart_color = "#da0205"
 
 /obj/machinery/light/spot
 	name = "spotlight"
@@ -182,6 +188,37 @@
 	light_type = /obj/item/weapon/light/tube/large
 	brightness_range = 12
 	brightness_power = 4
+	standart_color = "#FFFFFF"
+
+/obj/machinery/light/proc/alert_collor(alert = 0, ret = 0)
+	if(ret)	color_state = 3
+	if(!alert)
+		if(get_security_level() == "green")
+			if(color_state == 1 || color_state == 0) return
+			set_light(l_range = light_range, l_power = light_power, l_color = standart_color)
+			color_state = 1
+			return
+		if(get_security_level() == "blue")
+			if(color_state == 1 || color_state == 0) return
+			set_light(l_range = light_range, l_power = light_power, l_color = standart_color)
+			color_state = 1
+			return
+		if(get_security_level() == "red")
+			if(color_state == 2 || color_state == 0) return
+			set_light(l_range = light_range, l_power = light_power, l_color = "#FF6F6F")
+			color_state = 2
+			return
+		if(get_security_level() == "delta")
+			set_light(l_range = light_range, l_power = light_power, l_color = "#FF6633")
+			color_state = 3
+			return
+	if(alert)
+		set_light(l_range = light_range, l_power = light_power, l_color = "#FF6F6F")
+		color_state = 0
+		return
+
+
+
 
 /obj/machinery/light/built/New()
 	status = LIGHT_EMPTY

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -33,9 +33,9 @@
 				security_level = SEC_LEVEL_BLUE
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
-					security_announcement_up.Announce("[config.alert_desc_red_upto]", "Вниминие! Красный код!")
+					security_announcement_up.Announce("[config.alert_desc_red_upto]", "Внимание! Красный код!")
 				else
-					security_announcement_down.Announce("[config.alert_desc_red_downto]", "Вниминие! Красный код!")
+					security_announcement_down.Announce("[config.alert_desc_red_downto]", "Внимание! Красный код!")
 				security_level = SEC_LEVEL_RED
 				/*	- At the time of commit, setting status displays didn't work properly
 				var/obj/machinery/computer/communications/CC = locate(/obj/machinery/computer/communications,world)
@@ -49,6 +49,13 @@
 		for(var/obj/machinery/firealarm/FA in machines)
 			if(FA.z in using_map.contact_levels)
 				FA.set_security_level(newlevel)
+		for(var/obj/machinery/light/LT in machines)
+			if(security_level == 0 || security_level == 1 )
+				LT.alert_collor()
+			else
+				LT.set_light(l_range = LT.light_range, l_power = LT.light_power, l_color = LT.standart_color)
+				if(pick(1,0) == 1)
+					LT.alert_collor()
 
 
 /proc/get_security_level()


### PR DESCRIPTION
При красном или дельта коде безопасности лампы на станции становятся красными или оранжевыми соответственно. При синем\зеленом такого не будет.
* так же при вызове экстренного шатла, лампы будут красными как при красном коде безопасности.

**НА БЕЛЫЕ ПЯТНА НЕ ОБРАЩАТЬ ВНИМАНИЕ! ЭТО ИЗ ПРОЕКТА ПАРАЛЛАКСА КОСМОСА**

Красный код

![red](https://cloud.githubusercontent.com/assets/15817985/15085861/7e8040d0-13e5-11e6-8b01-179cf0889880.png)


Дельта код

![alpha](https://cloud.githubusercontent.com/assets/15817985/15085868/95e85fa0-13e5-11e6-9331-211930a38516.png)


